### PR TITLE
feat: add GET /api/v1/books/{book_id} endpoint

### DIFF
--- a/api/routes/books.py
+++ b/api/routes/books.py
@@ -1,9 +1,10 @@
 from typing import OrderedDict
 
-from fastapi import APIRouter, status
+from fastapi import APIRouter, status, HTTPException
 from fastapi.responses import JSONResponse
 
 from api.db.schemas import Book, Genre, InMemoryDB
+
 
 router = APIRouter()
 
@@ -60,3 +61,11 @@ async def update_book(book_id: int, book: Book) -> Book:
 async def delete_book(book_id: int) -> None:
     db.delete_book(book_id)
     return JSONResponse(status_code=status.HTTP_204_NO_CONTENT, content=None)
+
+@router.get("/{book_id}", status_code=status.HTTP_200_OK)
+async def get_book(book_id: int):
+    book = db.books.get(book_id) 
+    if book is None:
+        raise HTTPException(status_code=404, detail="Book not found")
+    return book
+


### PR DESCRIPTION
## Description  
- Added GET `/api/v1/books/{book_id}` endpoint to retrieve book details.  

## Related Task  
[HNG12 Stage 2 Task]  

## Testing  
- Ran `pytest` locally (all tests passed).  
- Tested invalid IDs (e.g., `/books/999`) to confirm 404 response.  

## Notes  
- Invited `hng12-devbotops` as a collaborator.  
