### PR TITLE
feat: Add fetch book by ID endpoint and CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: Run Tests
+
+on:
+  pull_request:
+    branches:
+      -  main
+
+jobs:
+  test:
+    runs_on: ubuntu-lastest
+    steps:
+      -  name: Checkout Code
+      -  uses: actions/checkout@v3
+
+      -  name: Set up Python
+      -  uses: actions/setup-python@4
+         with: 
+           python-version: 3.10
+
+      -  name: Install dependencies
+         run: |
+           python -m pip install --upgrade pip
+           pip install -r requirements.txt
+
+      -  name: Run tests
+         run: pytest

--- a/api/routes/books.py
+++ b/api/routes/books.py
@@ -60,3 +60,17 @@ async def update_book(book_id: int, book: Book) -> Book:
 async def delete_book(book_id: int) -> None:
     db.delete_book(book_id)
     return JSONResponse(status_code=status.HTTP_204_NO_CONTENT, content=None)
+
+
+@router.get("/{book_id}", response_model=Book, status_code=status.HTTP_200_OK)
+async def get_book(book_id: int) -> JSONResponse:
+    book = db.get_book(book_id)
+    if book is None:
+        return JSONResponse(
+            status_code=status.HTTP_404_NOT_FOUND,
+            content={"message": "Book not found."}
+        )
+    return JSONResponse(
+        status_code=status.HTTP_200_OK,
+        content=book.model_dump(),
+    )


### PR DESCRIPTION
## Description
- Added GET `/api/v1/books/{book_id}` endpoint to retrieve a book by its Id
- Added a CI pipeline line for pytest

## Related Task
[HNG12 Stage 2 Task]

## Testing
- Run `pytest` locally (all task passed)
- The endpoint returns a json response containing the book details or 404 error if the box doesn't exists
- Set up a CI pipeline to run pytest on pull requests to the main branch

## Notes
- Invited `hng12-devbotops` as a collaborator