### PR TITLE
feat: add GET /api/v1/books/{book_id} endpointRestore original content

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI Pipeline
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: pytest

--- a/api/routes/books.py
+++ b/api/routes/books.py
@@ -1,6 +1,6 @@
 from typing import OrderedDict
 
-from fastapi import APIRouter, status
+from fastapi import APIRouter, status, HTTPException
 from fastapi.responses import JSONResponse
 
 from api.db.schemas import Book, Genre, InMemoryDB
@@ -60,3 +60,11 @@ async def update_book(book_id: int, book: Book) -> Book:
 async def delete_book(book_id: int) -> None:
     db.delete_book(book_id)
     return JSONResponse(status_code=status.HTTP_204_NO_CONTENT, content=None)
+
+
+@router.get("/{book_id}")
+async def get_book_by_id(book_id: int):
+    book = db.books.get(book_id)
+    if book:
+        return book
+    raise HTTPException(status_code=404, detail="Book not found")


### PR DESCRIPTION
What: Adds a new endpoint to fetch a specific book by its ID (GET /api/v1/books/{book_id}).

Why: This feature allows the retrieval of book details by their unique ID.

How: Implemented logic to query the book from an in-memory database and return it as a response. If the book is not found, a 404 error is raised.