### PR TITLE
hngx_ stage2_task: add GET /api/v1/books/{book_id} endpoint

### DIFF
--- a/api/routes/books.py
+++ b/api/routes/books.py
@@ -2,6 +2,7 @@ from typing import OrderedDict
 
 from fastapi import APIRouter, status
 from fastapi.responses import JSONResponse
+from fastapi import HTTPException
 
 from api.db.schemas import Book, Genre, InMemoryDB
 
@@ -47,6 +48,12 @@ async def create_book(book: Book):
 async def get_books() -> OrderedDict[int, Book]:
     return db.get_books()
 
+@router.get("/{book_id}", response_model=Book, status_code=status.HTTP_200_OK)
+async def get_book(book_id:int) -> Book:
+    single_book = db.get_book(book_id)
+    if not single_book: 
+      raise HTTPException(status_code=404, detail="Book not found")   
+    return single_book
 
 @router.put("/{book_id}", response_model=Book, status_code=status.HTTP_200_OK)
 async def update_book(book_id: int, book: Book) -> Book:


### PR DESCRIPTION
## Description  
- Added GET `/api/v1/books/{book_id}` endpoint to retrieve book details.  
- Configured Nginx reverse proxy for FastAPI.  

## Related Task  
[HNG12 Stage 2 Task](#task-description-link)  

## Testing  
- Ran `pytest` locally (all tests passed).  
- Tested invalid IDs (e.g., `/books/999`) to confirm 404 response.  

## Notes  
- Invited `hng12-devbotops` as a collaborator.  
- Deployment URL: `https://your-app.com/`