### PR TITLE
feat: Added GET /api/v1/books/{book_id} endpoint & CI setup

### DIFF
--- a/.github/worflows/test.yml
+++ b/.github/worflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -18,7 +18,11 @@ jobs:
           python-version: '3.12'
 
       - name: Install dependencies
+        run: pip install --upgrade pip
         run: pip install -r requirements.txt
+
+      - name: Debug Python packages
+        run: pip list
 
       - name: Run tests
         run: pytest

--- a/.github/worflows/test.yml
+++ b/.github/worflows/test.yml
@@ -1,0 +1,24 @@
+name: CI Pipeline
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run tests
+        run: pytest

--- a/api/routes/books.py
+++ b/api/routes/books.py
@@ -1,6 +1,6 @@
 from typing import OrderedDict
 
-from fastapi import APIRouter, status
+from fastapi import APIRouter, status, HTTPException
 from fastapi.responses import JSONResponse
 
 from api.db.schemas import Book, Genre, InMemoryDB
@@ -46,6 +46,20 @@ async def create_book(book: Book):
 )
 async def get_books() -> OrderedDict[int, Book]:
     return db.get_books()
+
+
+@router.get("/{book_id}", response_model=Book, status_code=status.HTTP_200_OK)
+async def get_book(book_id: int):
+    book = db.get_book(book_id)  # Fetch book from the database
+    
+    if not book:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Book not found",
+        )
+
+    return book
+
 
 
 @router.put("/{book_id}", response_model=Book, status_code=status.HTTP_200_OK)


### PR DESCRIPTION
## Description
- Added GET `/api/v1/books/{book_id}` endpoint to retrieve book details.
- Configured Nginx reverse proxy for FastAPI.
## Testing
- Ran `pytest` locally (all tests passed).
- Tested invalid IDs (e.g., /books/
999) to confirm 404 response.
## Notes
- Invited `hng12-devbot` as a collaborator