### PR TITLE
feat: add GET book by book_id endpoint

### DIFF
--- a/api/routes/books.py
+++ b/api/routes/books.py
@@ -1,6 +1,6 @@
 from typing import OrderedDict
 
-from fastapi import APIRouter, status
+from fastapi import APIRouter, status, HTTPException
 from fastapi.responses import JSONResponse
 
 from api.db.schemas import Book, Genre, InMemoryDB
@@ -41,12 +41,17 @@ async def create_book(book: Book):
     )
 
 
-@router.get(
-    "/", response_model=OrderedDict[int, Book], status_code=status.HTTP_200_OK
-)
+@router.get("/", response_model=OrderedDict[int, Book], status_code=status.HTTP_200_OK)
 async def get_books() -> OrderedDict[int, Book]:
     return db.get_books()
 
+
+@router.get("/{book_id}", response_model=Book, status_code=status.HTTP_200_OK)
+async def get_book(book_id: int):
+    book = db.get_book(book_id)
+    if not book:
+       raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Book not found")
+    return book 
 
 @router.put("/{book_id}", response_model=Book, status_code=status.HTTP_200_OK)
 async def update_book(book_id: int, book: Book) -> Book:


### PR DESCRIPTION
### What was added?
- Implemented `GET /api/v1/books/{book_id}` to fetch book details.
- Returns `200 OK` if the book exists.
- Returns `404 Not Found` if the book ID does not exist.

### Why is this change necessary?
- Required for HNG12 Stage 2 backend task.
- Ensures proper error handling and response consistency.

### How was it tested?
- Manually tested with valid and invalid book IDs.
- Ensured FastAPI handles responses correctly.