### PR TITLE
Updated missing endpoint GET api/books/{book_id}

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Use an official Python runtime as a base image
+FROM python:3.10-slim
+
+# Prevent Python from writing .pyc files to disk
+ENV PYTHONDONTWRITEBYTECODE 1
+# Prevent Python from buffering stdout and stderr
+ENV PYTHONUNBUFFERED 1
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the requirements file into the container
+COPY requirements.txt .
+
+# Upgrade pip and install the required Python packages
+RUN pip install --upgrade pip && pip install -r requirements.txt
+
+# Copy the rest of the application code into the container
+COPY . .
+
+# Expose port 8000 for the FastAPI application
+EXPOSE 8000
+
+# Command to run the FastAPI application using uvicorn
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+

--- a/api/routes/books.py
+++ b/api/routes/books.py
@@ -41,11 +41,21 @@ async def create_book(book: Book):
     )
 
 
-@router.get(
-    "/", response_model=OrderedDict[int, Book], status_code=status.HTTP_200_OK
-)
+@router.get("/", response_model=OrderedDict[int, Book], status_code=status.HTTP_200_OK)
 async def get_books() -> OrderedDict[int, Book]:
     return db.get_books()
+
+
+# NEW ENDPOINT: Retrieve a single book by its ID.
+@router.get("/{book_id}", response_model=Book, status_code=status.HTTP_200_OK)
+async def get_book(book_id: int):
+    book = db.get_book(book_id)
+    if book is None:
+        return JSONResponse(
+            status_code=status.HTTP_404_NOT_FOUND,
+            content={"detail": "Book not found"}
+        )
+    return book
 
 
 @router.put("/{book_id}", response_model=Book, status_code=status.HTTP_200_OK)


### PR DESCRIPTION
## Description  
- Added GET `/api/v1/books/{book_id}` endpoint to retrieve book details.  
- Configured Nginx reverse proxy for FastAPI.  

## Related Task  
[HNG12 Stage 2 Task](#task-description-link)  

## Testing  
- Ran `pytest` locally (all tests passed).  
- Tested invalid IDs (e.g., `/books/999`) to confirm 404 response.  

## Notes  
- Invited `hng12-devbotops` as a collaborator.  
- Deployment URL: `https://your-app.com/`